### PR TITLE
Integrate reCAPTCHA and chat services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # LoveNow
+
+## Configuration (Netlify)
+
+Remplir `config.js` avec les clés publiques :
+
+- `FIREBASE_API_KEY`, `FIREBASE_AUTH_DOMAIN`, `FIREBASE_PROJECT_ID`, `FIREBASE_APP_ID`, `FIREBASE_STORAGE_BUCKET`
+- `RECAPTCHA_SITE_KEY`
+- `CHAT_PROVIDER` ("recapchat" ou "none")
+- `CHAT_SITE_ID`
+
+Variables d’environnement privées à définir sur Netlify :
+
+- `RECAPTCHA_SECRET` (clé secrète reCAPTCHA)
+
+Le fichier `js/firebase.js` utilise ces valeurs pour initialiser Firebase.
+
+### Règles Firestore recommandées
+
+Voir `firestore.rules` :
+
+```
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /users/{uid} {
+      allow read: if true;
+      allow write: if request.auth != null && request.auth.uid == uid;
+    }
+  }
+}
+```
+

--- a/config.js
+++ b/config.js
@@ -32,3 +32,15 @@ window.APP_CONFIG = {
   analyticsEnabled: false,
   resendCooldown: 30
 };
+
+// Mapping simplifié des clés publiques pour les modules JS
+window.env = {
+  FIREBASE_API_KEY: window.APP_CONFIG.firebase.apiKey,
+  FIREBASE_AUTH_DOMAIN: window.APP_CONFIG.firebase.authDomain,
+  FIREBASE_PROJECT_ID: window.APP_CONFIG.firebase.projectId,
+  FIREBASE_APP_ID: window.APP_CONFIG.firebase.appId,
+  FIREBASE_STORAGE_BUCKET: window.APP_CONFIG.firebase.storageBucket,
+  RECAPTCHA_SITE_KEY: '',       // à renseigner
+  CHAT_PROVIDER: '',            // ex: 'recapchat'
+  CHAT_SITE_ID: ''              // ex: 'abcdef'
+};

--- a/conversations.html
+++ b/conversations.html
@@ -27,7 +27,7 @@
     <a href="/" aria-label="Retour accueil">← Accueil</a>
     <h1>Conversations</h1>
 
-    <article class="card" aria-live="polite">
+    <article class="card" id="verifyCard" aria-live="polite">
       <p><strong>E-mail non vérifié :</strong> vérifiez votre e-mail pour pouvoir envoyer des messages.</p>
       <div class="actions" style="display:flex;gap:8px;flex-wrap:wrap">
         <button class="btn" id="btnResend">Renvoyer le lien de vérification</button>
@@ -40,15 +40,25 @@
 
   <div id="toast" role="status" aria-live="polite"></div>
 
-  <script>
+  <script src="/config.js"></script>
+  <script type="module">
+    import { auth, sendEmailVerification, onAuthStateChanged } from './js/firebase.js';
+    import './js/chat.js';
     const toast = document.getElementById('toast');
     const showToast = m => { toast.textContent=m; toast.style.display='block'; setTimeout(()=>toast.style.display='none', 2200); };
+    let current = null;
+
+    onAuthStateChanged(u=>{
+      if(!u){ location.href='/login.html#signup'; return; }
+      current = u;
+      document.getElementById('verifyCard').style.display = u.emailVerified ? 'none':'block';
+    });
 
     document.getElementById('btnResend').addEventListener('click', async ()=>{
+      if(!current) return;
       showToast('Envoi en cours…');
       try{
-        // Appelle ici ton API (Firebase) pour renvoyer le lien
-        await new Promise(r=>setTimeout(r, 700)); // démo
+        await sendEmailVerification(current);
         showToast('Lien envoyé ✅');
       }catch(e){
         showToast('Échec d’envoi ❌');
@@ -56,10 +66,11 @@
     });
 
     document.getElementById('btnRefresh').addEventListener('click', async ()=>{
+      if(!current) return;
       showToast('Actualisation…');
-      // Branche ici la vérification réelle de l’état de l’utilisateur
-      await new Promise(r=>setTimeout(r, 400));
+      await current.reload();
       showToast('État mis à jour');
+      document.getElementById('verifyCard').style.display = current.emailVerified ? 'none':'block';
     });
   </script>
 </body>

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,9 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /users/{uid} {
+      allow read: if true;
+      allow write: if request.auth != null && request.auth.uid == uid;
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -62,10 +62,9 @@
         <div class="grow"></div>
         <a href="/#discover" class="ghost btn">Découvrir</a>
         <a href="/conversations.html" class="ghost btn">Conversations</a>
-        <a href="/profile.html" class="ghost btn">Mon profil</a>
         <a href="/privacy.html" class="ghost btn">Confidentialité</a>
         <a href="/cgu.html" class="ghost btn">CGU</a>
-        <a href="/login.html#signup" class="btn">Rejoins-nous gratuitement</a>
+        <span id="header-session"></span>
       </nav>
     </div>
   </header>
@@ -117,6 +116,7 @@
 
         <div id="results" class="cards" aria-live="polite"></div>
         <p id="empty-hint" class="muted" style="display:none">Ajuste les filtres ou complète ton profil pour voir plus de résultats.</p>
+        <p style="text-align:center"><button id="btnMore" class="btn" type="button" style="display:none">Charger plus…</button></p>
       </div>
     </section>
   </main>
@@ -129,19 +129,37 @@
     </div>
   </footer>
 
-  <script>
-    // --- STATE & DATA (demo local) ---
-    const state = { filters: {}, data: [] }; // data: à brancher sur ta source réelle
+  <script src="/config.js"></script>
+  <script type="module">
+    import { onAuthStateChanged, listenProfiles, queryProfilesOnce, signOut } from './js/firebase.js';
+    import './js/chat.js';
 
-    // Placeholder minimal pour la démo : tableau vide -> skeletons
-    state.data = []; // laisse vide par défaut
+    // --- STATE ---
+    const state = { filters: {}, lastDoc: null };
+    let unsub = null;
 
     const $ = s => document.querySelector(s);
     const resultsEl = $('#results');
     const emptyHintEl = $('#empty-hint');
     const toast = $('#toast');
+    const btnMore = $('#btnMore');
+    let currentUser = null;
 
     function showToast(msg){ toast.textContent = msg; toast.style.display='block'; setTimeout(()=>toast.style.display='none', 2500); }
+
+    onAuthStateChanged(u => {
+      currentUser = u;
+      const slot = document.getElementById('header-session');
+      if(slot){
+        if(u){
+          const initial = (u.displayName||u.email||'?')[0].toUpperCase();
+          slot.innerHTML = `<a href="/profile.html" class="ghost btn">${initial}</a> <button id="btnSignOut" class="ghost btn">Se déconnecter</button>`;
+          document.getElementById('btnSignOut').onclick = ()=>signOut();
+        }else{
+          slot.innerHTML = `<a href="/login.html#signup" class="btn">Rejoins-nous gratuitement</a>`;
+        }
+      }
+    });
 
     // URL <-> state
     function readURL(){
@@ -172,24 +190,43 @@
       resultsEl.innerHTML = Array.from({length:n}).map(()=>'<div class="skel" aria-hidden="true"></div>').join('');
       emptyHintEl.style.display = 'block';
     }
-    function renderCards(items){
-      if(!items.length){ renderSkeletons(); return; }
-      emptyHintEl.style.display = 'none';
-      resultsEl.innerHTML = items.map(it => `
+    function renderCards(items, append=false){
+      if(!append){ resultsEl.innerHTML = ''; }
+      if(!items.length && !append){ renderSkeletons(); return; }
+      emptyHintEl.style.display = items.length ? 'none':'block';
+      const html = items.map(it => `
         <article class="card" tabindex="0" aria-label="Profil">
-          <div style="font-weight:700">${it.name || 'Prénom'}</div>
+          <div style="font-weight:700">${it.displayName || 'Prénom'}</div>
           <div class="muted">${(it.age||'—')} ans · ${it.city||'—'}</div>
           <p>${it.bio || '—'}</p>
-          <a class="btn ghost" href="/login.html#signup">Dire bonjour</a>
+          <a class="btn ghost" href="${currentUser?'/conversations.html':'/login.html#signup'}">Dire bonjour</a>
         </article>
       `).join('');
+      resultsEl.insertAdjacentHTML('beforeend', html);
     }
 
     function applyFilters(){
-      // Ici, filtre state.data selon state.filters si tu as des données
-      const items = []; // filtrage réel à implémenter si data existe
-      renderCards(items);
+      renderSkeletons();
+      if(unsub) unsub();
+      unsub = listenProfiles({
+        filters: state.filters,
+        pageSize: 6,
+        onNext: (profiles)=>{
+          state.lastDoc = profiles.length ? profiles[profiles.length-1]._doc : null;
+          renderCards(profiles);
+          btnMore.style.display = profiles.length === 6 ? 'inline-block' : 'none';
+        }
+      });
     }
+
+    btnMore.addEventListener('click', async ()=>{
+      btnMore.disabled = true;
+      const { profiles, lastDoc } = await queryProfilesOnce({ filters: state.filters, pageSize:6, startAfterDoc: state.lastDoc });
+      state.lastDoc = lastDoc;
+      renderCards(profiles, true);
+      btnMore.disabled = false;
+      if(!lastDoc) btnMore.style.display='none';
+    });
 
     // Events
     $('#btnSearch').addEventListener('click', () => {

--- a/js/chat.js
+++ b/js/chat.js
@@ -1,0 +1,16 @@
+const provider = window.env?.CHAT_PROVIDER;
+const siteId = window.env?.CHAT_SITE_ID;
+
+if (provider === 'recapchat' && siteId) {
+  window.addEventListener('load', () => {
+    const s = document.createElement('script');
+    s.src = 'https://cdn.recapchat.com/widget.js';
+    s.async = true;
+    s.onload = () => {
+      try {
+        window.RecapChat?.init?.({ siteId, open: false });
+      } catch (_e) {}
+    };
+    document.head.appendChild(s);
+  });
+}

--- a/js/firebase-config.sample.js
+++ b/js/firebase-config.sample.js
@@ -1,0 +1,8 @@
+// Copiez ce fichier en firebase-config.js et remplissez vos valeurs Firebase
+window.env = {
+  FIREBASE_API_KEY: 'xxx',
+  FIREBASE_AUTH_DOMAIN: 'xxx.firebaseapp.com',
+  FIREBASE_PROJECT_ID: 'xxx',
+  FIREBASE_APP_ID: 'xxx',
+  FIREBASE_STORAGE_BUCKET: 'xxx.appspot.com'
+};

--- a/js/firebase.js
+++ b/js/firebase.js
@@ -1,0 +1,92 @@
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
+import { getAuth, onAuthStateChanged as onAuth, createUserWithEmailAndPassword, signInWithEmailAndPassword, signOut as fbSignOut, sendEmailVerification as fbSendEmailVerification, updateProfile as fbUpdateProfile } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
+import { getFirestore, doc, setDoc, getDoc, serverTimestamp, collection, query, where, orderBy, limit, onSnapshot, startAfter, getDocs } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+
+const cfg = {
+  apiKey:        window.env?.FIREBASE_API_KEY        || window.APP_CONFIG?.firebase?.apiKey,
+  authDomain:    window.env?.FIREBASE_AUTH_DOMAIN    || window.APP_CONFIG?.firebase?.authDomain,
+  projectId:     window.env?.FIREBASE_PROJECT_ID     || window.APP_CONFIG?.firebase?.projectId,
+  appId:         window.env?.FIREBASE_APP_ID         || window.APP_CONFIG?.firebase?.appId,
+  storageBucket: window.env?.FIREBASE_STORAGE_BUCKET || window.APP_CONFIG?.firebase?.storageBucket,
+};
+
+const app = initializeApp(cfg);
+export const auth = getAuth(app);
+export const db = getFirestore(app);
+export const sendEmailVerification = fbSendEmailVerification;
+
+export async function signUp(email, pass, profile){
+  const { user } = await createUserWithEmailAndPassword(auth, email, pass);
+  await fbSendEmailVerification(user);
+  if(profile?.displayName){
+    try{ await fbUpdateProfile(user, { displayName: profile.displayName }); }catch(e){}
+  }
+  const ref = doc(db, 'users', user.uid);
+  await setDoc(ref, {
+    uid: user.uid,
+    email: user.email,
+    emailVerified: user.emailVerified,
+    displayName: profile?.displayName || '',
+    city: profile?.city || '',
+    age: Number(profile?.age) || null,
+    gender: profile?.gender || '',
+    bio: profile?.bio || '',
+    photoURL: profile?.photoURL || '',
+    createdAt: serverTimestamp(),
+    updatedAt: serverTimestamp()
+  }, { merge:true });
+  return user;
+}
+
+export async function signIn(email, pass){
+  const { user } = await signInWithEmailAndPassword(auth, email, pass);
+  return user;
+}
+
+export function onAuthStateChanged(cb){ return onAuth(auth, cb); }
+
+export async function signOut(){ return fbSignOut(auth); }
+
+export async function updateProfileDoc(partial){
+  const u = auth.currentUser;
+  if(!u) throw new Error('not-authenticated');
+  const ref = doc(db, 'users', u.uid);
+  await setDoc(ref, { ...partial, updatedAt: serverTimestamp() }, { merge:true });
+}
+
+export async function getProfile(uid){
+  const ref = doc(db, 'users', uid);
+  const snap = await getDoc(ref);
+  return snap.exists() ? snap.data() : null;
+}
+
+export function listenProfiles({filters={}, pageSize=12, onNext}){
+  const col = collection(db, 'users');
+  const clauses = [];
+  if(filters.gender) clauses.push(where('gender','==',filters.gender));
+  if(filters.city)   clauses.push(where('city','==',filters.city));
+  let q = query(col, ...clauses, orderBy('createdAt','desc'), limit(pageSize));
+  const unsub = onSnapshot(q, snap => {
+    const list = snap.docs.map(d=>{
+      const { displayName, age, city, bio, photoURL, uid } = d.data();
+      return { displayName, age, city, bio, photoURL, uid, _doc:d };
+    });
+    onNext(list);
+  });
+  return unsub;
+}
+
+export async function queryProfilesOnce({filters={}, pageSize=12, startAfterDoc}){
+  const col = collection(db, 'users');
+  const clauses = [];
+  if(filters.gender) clauses.push(where('gender','==',filters.gender));
+  if(filters.city)   clauses.push(where('city','==',filters.city));
+  let q = query(col, ...clauses, orderBy('createdAt','desc'), limit(pageSize));
+  if(startAfterDoc) q = query(col, ...clauses, orderBy('createdAt','desc'), startAfter(startAfterDoc), limit(pageSize));
+  const snap = await getDocs(q);
+  const list = snap.docs.map(d=>{
+    const { displayName, age, city, bio, photoURL, uid } = d.data();
+    return { displayName, age, city, bio, photoURL, uid, _doc:d };
+  });
+  return { profiles:list, lastDoc: snap.docs[snap.docs.length-1] };
+}

--- a/js/recaptcha.js
+++ b/js/recaptcha.js
@@ -1,0 +1,25 @@
+const SITE_KEY = window.env?.RECAPTCHA_SITE_KEY;
+let loading;
+
+export async function getRecaptchaToken(action){
+  if(!SITE_KEY) return null;
+  await load();
+  try{
+    return await grecaptcha.execute(SITE_KEY, { action });
+  }catch(e){
+    return null;
+  }
+}
+
+function load(){
+  if(loading) return loading;
+  loading = new Promise((resolve, reject)=>{
+    const s = document.createElement('script');
+    s.src = `https://www.google.com/recaptcha/api.js?render=${SITE_KEY}`;
+    s.async = true;
+    s.onload = () => resolve();
+    s.onerror = () => reject();
+    document.head.appendChild(s);
+  });
+  return loading;
+}

--- a/login.html
+++ b/login.html
@@ -36,12 +36,13 @@
     </div>
 
     <section id="panel-login" role="tabpanel" aria-labelledby="tab-login" hidden>
-      <form onsubmit="event.preventDefault(); alert('Connexion… (branche ton backend)')">
+      <form id="loginForm" onsubmit="return doLogin(event)">
         <label for="lemail">Email</label>
         <input id="lemail" type="email" required>
         <label for="lpass">Mot de passe</label>
         <input id="lpass" type="password" required minlength="6">
-        <button class="btn" type="submit">Se connecter</button>
+        <div id="loginError" class="error" role="status" aria-live="polite"></div>
+        <button id="btnLogin" class="btn" type="submit">Se connecter</button>
       </form>
     </section>
 
@@ -55,12 +56,20 @@
         <input id="sage" type="number" inputmode="numeric" min="18" max="99" placeholder="18" required aria-describedby="ageHelp">
         <small id="ageHelp" class="muted">Le service est réservé aux personnes de 18 ans et plus.</small>
         <div id="signupError" class="error" role="status" aria-live="polite"></div>
-        <button class="btn" type="submit">Créer un compte</button>
+        <button id="btnSignup" class="btn" type="submit">Créer un compte</button>
       </form>
     </section>
   </div>
+  <div id="toast" role="status" aria-live="polite"></div>
 
-  <script>
+  <script src="/config.js"></script>
+  <script type="module">
+    import { signUp, signIn } from './js/firebase.js';
+    import { getRecaptchaToken } from './js/recaptcha.js';
+    import './js/chat.js';
+    const toast = document.getElementById('toast');
+    const showToast = m => { toast.textContent=m; toast.style.display='block'; setTimeout(()=>toast.style.display='none',2200); };
+
     // Tabs + hash #signup
     const tLogin = document.getElementById('tab-login');
     const tSignup = document.getElementById('tab-signup');
@@ -80,17 +89,66 @@
     window.addEventListener('hashchange', fromHash);
     fromHash();
 
-    function validateSignup(e){
+    async function validateSignup(e){
+      e.preventDefault();
       const age = parseInt(document.getElementById('sage').value, 10);
       const err = document.getElementById('signupError');
+      const btn = document.getElementById('btnSignup');
       if(!Number.isFinite(age) || age < 18){
         err.textContent = 'Vous devez avoir 18 ans ou plus pour créer un compte.';
         document.getElementById('sage').focus();
         return false;
       }
       err.textContent = '';
-      alert('Inscription… (branche ton backend)'); // à remplacer par ton flux réel
+      btn.disabled = true;
+      btn.textContent = 'Création…';
+      try{
+        const token = await getRecaptchaToken('signup');
+        if(token){
+          const resp = await fetch('/.netlify/functions/verify-recaptcha', {
+            method:'POST',
+            headers:{'Content-Type':'application/json'},
+            body: JSON.stringify({ token })
+          });
+          const data = await resp.json();
+          if(!resp.ok || !data.success){ throw new Error('reCAPTCHA invalide'); }
+        }
+        await signUp(document.getElementById('semail').value.trim(), document.getElementById('spass').value, { age });
+        showToast('Compte créé. Vérifiez votre e-mail.');
+        location.href = '/profile.html';
+      }catch(ex){
+        err.textContent = ex.message;
+      }finally{
+        btn.disabled = false;
+        btn.textContent = 'Créer un compte';
+      }
+      return false;
+    }
+
+    async function doLogin(e){
       e.preventDefault();
+      const err = document.getElementById('loginError');
+      const btn = document.getElementById('btnLogin');
+      err.textContent = '';
+      btn.disabled = true; btn.textContent = 'Connexion…';
+      try{
+        const token = await getRecaptchaToken('login');
+        if(token){
+          const resp = await fetch('/.netlify/functions/verify-recaptcha', {
+            method:'POST',
+            headers:{'Content-Type':'application/json'},
+            body: JSON.stringify({ token })
+          });
+          const data = await resp.json();
+          if(!resp.ok || !data.success){ throw new Error('reCAPTCHA invalide'); }
+        }
+        await signIn(document.getElementById('lemail').value.trim(), document.getElementById('lpass').value);
+        location.href = '/';
+      }catch(ex){
+        err.textContent = ex.message;
+      }finally{
+        btn.disabled = false; btn.textContent = 'Se connecter';
+      }
       return false;
     }
   </script>

--- a/netlify/functions/verify-recaptcha.js
+++ b/netlify/functions/verify-recaptcha.js
@@ -1,0 +1,30 @@
+import fetch from 'node-fetch';
+
+export async function handler(event) {
+  const secret = process.env.RECAPTCHA_SECRET;
+  if (!secret) {
+    return { statusCode: 500, body: JSON.stringify({ success: false, errors: ['missing-secret'] }) };
+  }
+  let token;
+  try {
+    ({ token } = JSON.parse(event.body || '{}'));
+  } catch {
+    return { statusCode: 400, body: JSON.stringify({ success: false, errors: ['invalid-body'] }) };
+  }
+  if (!token) {
+    return { statusCode: 400, body: JSON.stringify({ success: false, errors: ['missing-token'] }) };
+  }
+  try {
+    const resp = await fetch('https://www.google.com/recaptcha/api/siteverify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: `secret=${encodeURIComponent(secret)}&response=${encodeURIComponent(token)}`
+    });
+    const data = await resp.json();
+    const { success = false, score = 0, action = '', ['error-codes']: errors = [] } = data;
+    const ok = success && score >= 0.5;
+    return { statusCode: ok ? 200 : 400, body: JSON.stringify({ success, score, action, errors }) };
+  } catch (err) {
+    return { statusCode: 500, body: JSON.stringify({ success: false, errors: [err.message] }) };
+  }
+}

--- a/profile.html
+++ b/profile.html
@@ -46,15 +46,18 @@
       <label for="bio">Bio</label>
       <textarea id="bio" maxlength="600" placeholder="Parlez un peu de vous…"></textarea>
 
-      <button class="btn" type="submit">Enregistrer</button>
+      <button id="btnSave" class="btn" type="submit">Enregistrer</button>
     </form>
   </div>
 
   <div id="toast" role="status" aria-live="polite"></div>
 
-  <script>
+  <script src="/config.js"></script>
+  <script type="module">
+    import { onAuthStateChanged, getProfile, updateProfileDoc } from './js/firebase.js';
+    import './js/chat.js';
     const toast = document.getElementById('toast');
-    function showToast(m){ toast.textContent=m; toast.style.display='block'; setTimeout(()=>toast.style.display='none', 2200); }
+    const showToast = m => { toast.textContent=m; toast.style.display='block'; setTimeout(()=>toast.style.display='none',2200); };
 
     const fileInput = document.getElementById('avatar');
     const preview = document.getElementById('preview');
@@ -90,14 +93,36 @@
       preview.src = URL.createObjectURL(blob);
       preview.hidden = false;
 
-      // À ce stade, "blob" = image prête pour upload (brancher ici Cloudinary/Firebase)
-      // window.uploadImage(blob) ...
+      // TODO: uploader l'image et obtenir l'URL puis sauvegarder via updateProfileDoc({photoURL})
     });
 
-    function saveProfile(e){
+    onAuthStateChanged(async u => {
+      if(!u){ location.href = '/login.html#signup'; return; }
+      const data = await getProfile(u.uid) || {};
+      if(data.photoURL){ preview.src = data.photoURL; preview.hidden = false; }
+      document.getElementById('name').value = data.displayName || '';
+      document.getElementById('city').value = data.city || '';
+      document.getElementById('age').value = data.age || '';
+      document.getElementById('bio').value = data.bio || '';
+    });
+
+    async function saveProfile(e){
       e.preventDefault();
-      // Brancher ici l’enregistrement réel (Firebase, etc.)
-      showToast('Profil enregistré (exemple)');
+      const btn = document.getElementById('btnSave');
+      btn.disabled = true; btn.textContent='Enregistrement…';
+      try{
+        await updateProfileDoc({
+          displayName: document.getElementById('name').value.trim(),
+          city: document.getElementById('city').value.trim(),
+          age: parseInt(document.getElementById('age').value,10),
+          bio: document.getElementById('bio').value.trim()
+        });
+        showToast('Profil enregistré');
+      }catch(ex){
+        showToast('Erreur: '+ex.message);
+      }finally{
+        btn.disabled = false; btn.textContent='Enregistrer';
+      }
       return false;
     }
   </script>


### PR DESCRIPTION
## Summary
- map public config values and expose `window.env`
- add reCAPTCHA client helper with Netlify verification function
- load RecapChat widget based on configuration and stream Firestore profiles in real-time
- resolve merge conflicts keeping PR branch versions of auth/recaptcha/chat pages

## Fichiers modifiés
- `config.js`
- `js/recaptcha.js`
- `netlify/functions/verify-recaptcha.js`
- `js/chat.js`
- `login.html`
- `profile.html`
- `index.html`
- `conversations.html`
- `README.md`

## Checklist QA (iPhone)
- [ ] Inscription (≥18) → compte créé, e-mail de vérif envoyé, pas d’alertes legacy.
- [ ] Connexion → redirige vers /, header affiche initiale/avatar + Mon profil/Se déconnecter.
- [ ] Profil → chargement et sauvegarde doc users/{uid} → toast « Profil enregistré ».
- [ ] Home → profils s’affichent en temps réel ; filtres actifs ; « Charger plus… » si présent.
- [ ] Conversations → « Renvoyer le lien » affiche toasts ; « Rafraîchir l’état » fonctionne.
- [ ] reCAPTCHA → token généré et validé (logs Netlify Function ok).
- [ ] Chat RecapChat → widget chargé (minimisé) quand config fournie ; absent sinon.
- [ ] A11y → focus visible, aria-live pour messages ; aucun bouton inactif « muet ».
- [ ] Pas de secrets en dur ; README mis à jour ; fichiers hors périmètre intacts.

## À renseigner
- `FIREBASE_API_KEY`, `FIREBASE_AUTH_DOMAIN`, `FIREBASE_PROJECT_ID`, `FIREBASE_APP_ID`, `FIREBASE_STORAGE_BUCKET`
- `RECAPTCHA_SITE_KEY`
- `RECAPTCHA_SECRET`
- `CHAT_PROVIDER`, `CHAT_SITE_ID`

## Rollback
- Revert PR #<PR_NUMBER>


------
https://chatgpt.com/codex/tasks/task_e_68c19552fe44832a8355309af54c2c7c