### PR TITLE
feat(recaptcha): add Netlify verify function + set site key

### DIFF
--- a/config.js
+++ b/config.js
@@ -32,3 +32,6 @@ window.APP_CONFIG = {
   analyticsEnabled: false,
   resendCooldown: 30
 };
+
+window.env = window.env || {};
+window.env.RECAPTCHA_SITE_KEY = "6LfjpsErAAAAAExN2IvBq-K475TeJooeNzl9liPD";

--- a/netlify/functions/verify-recaptcha.js
+++ b/netlify/functions/verify-recaptcha.js
@@ -1,0 +1,55 @@
+/**
+ * Netlify Function: verify-recaptcha
+ * Valide un token reCAPTCHA via l’API Google.
+ * Requiert la variable d’environnement Netlify: RECAPTCHA_SECRET.
+ * Répond en JSON. CORS permissif.
+ */
+exports.handler = async (event) => {
+  const headers = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'content-type',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS'
+  };
+
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers };
+  }
+
+  try {
+    const secret = process.env.RECAPTCHA_SECRET;
+    if (!secret) {
+      return { statusCode: 500, headers, body: JSON.stringify({ success:false, error:'missing-secret' }) };
+    }
+
+    let token;
+    try {
+      ({ token } = JSON.parse(event.body || '{}'));
+    } catch {
+      return { statusCode: 400, headers, body: JSON.stringify({ success:false, error:'invalid-json' }) };
+    }
+    if (!token) {
+      return { statusCode: 400, headers, body: JSON.stringify({ success:false, error:'missing-token' }) };
+    }
+
+    const params = new URLSearchParams({ secret, response: token });
+    const resp = await fetch('https://www.google.com/recaptcha/api/siteverify', {
+      method: 'POST',
+      body: params
+    });
+    const data = await resp.json();
+
+    const ok = !!data.success && (data.score === undefined || data.score >= 0.5);
+    return {
+      statusCode: 200,
+      headers,
+      body: JSON.stringify({
+        success: ok,
+        score: data.score,
+        action: data.action,
+        errors: data['error-codes'] || []
+      })
+    };
+  } catch (e) {
+    return { statusCode: 500, headers, body: JSON.stringify({ success:false, error:String(e) }) };
+  }
+};


### PR DESCRIPTION
## Summary
- add Netlify Function to validate reCAPTCHA tokens
- expose RECAPTCHA_SITE_KEY in config.js

### Configuration requise (à faire sur Netlify)
1. Site settings → Environment variables → ajouter :
   - RECAPTCHA_SECRET = **6LfjpsErAAAAABYc5XRYq8T5uxCQsqacxW3djvHW**  ← (ne pas committer)
2. Redéployer.

### Test rapide
- Endpoint: `/.netlify/functions/verify-recaptcha`
- cURL (token bidon, attendu: success:false) :
  ```bash
  curl -X POST -H "Content-Type: application/json" -d '{"token":"test"}' https://deploy-preview-123--lovenow.netlify.app/.netlify/functions/verify-recaptcha
  ```


------
https://chatgpt.com/codex/tasks/task_e_68c1b6f157f4832abe5d170183cdc5a5