### PR TITLE
feat(chat): integrate Crisp widget via chat.js and CSP updates

### DIFF
--- a/cgu.html
+++ b/cgu.html
@@ -31,8 +31,9 @@
     <h2>Responsabilités</h2>
     <p>LoveNow fournit une mise en relation ; chaque utilisateur reste responsable de son comportement et de ses contenus.</p>
 
-    <h2>Confidentialité</h2>
-    <p>Consultez notre <a href="/privacy.html">Politique de confidentialité</a> pour les informations relatives aux données personnelles.</p>
-  </div>
-</body>
-</html>
+      <h2>Confidentialité</h2>
+      <p>Consultez notre <a href="/privacy.html">Politique de confidentialité</a> pour les informations relatives aux données personnelles.</p>
+    </div>
+    <script src="chat.js"></script>
+  </body>
+  </html>

--- a/chat.js
+++ b/chat.js
@@ -1,0 +1,11 @@
+(function () {
+  var C = window.APP_CONFIG || {};
+  if (C.CHAT_PROVIDER === "crisp" && C.CHAT_SITE_ID && !window.CRISP_WEBSITE_ID) {
+    window.$crisp = window.$crisp || [];
+    window.CRISP_WEBSITE_ID = C.CHAT_SITE_ID;
+    var s = document.createElement("script");
+    s.src = "https://client.crisp.chat/l.js";
+    s.async = 1;
+    document.head.appendChild(s);
+  }
+})();

--- a/config.js
+++ b/config.js
@@ -30,7 +30,9 @@ window.APP_CONFIG = {
   },
 
   analyticsEnabled: false,
-  resendCooldown: 30
+  resendCooldown: 30,
+  CHAT_PROVIDER: "crisp",
+  CHAT_SITE_ID: "42383cbe-1349-42c2-a0ef-04386b58ccd6"
 };
 
 window.env = window.env || {};

--- a/conversations.html
+++ b/conversations.html
@@ -57,5 +57,6 @@
       catch(e){ showToast('Erreur'); }
     });
   </script>
+  <script src="chat.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -182,7 +182,8 @@
     // Init
     renderSkeletons();
     apply(state.filters);
-    loadChat();
+  loadChat();
   </script>
+  <script src="chat.js"></script>
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -101,7 +101,7 @@
     });
 
     // Login
-    document.getElementById('loginForm').addEventListener('submit', async (e)=>{
+  document.getElementById('loginForm').addEventListener('submit', async (e)=>{
       e.preventDefault();
       const btn = document.getElementById('btnLogin'); setLoading(btn,true);
       const err = document.getElementById('loginError'); err.textContent='';
@@ -118,7 +118,8 @@
         location.href='/';
       }catch(ex){ err.textContent = ex?.message || 'Erreur inconnue'; }
       finally{ setLoading(btn,false); }
-    });
+  });
   </script>
+  <script src="chat.js"></script>
 </body>
 </html>

--- a/netlify.toml
+++ b/netlify.toml
@@ -48,5 +48,5 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy-Report-Only = "default-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; connect-src 'self' https:; font-src 'self' https: data:; report-to csp-endpoint;"
+    Content-Security-Policy-Report-Only = "default-src 'self'; img-src 'self' data: https: https://*.crisp.chat; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://client.crisp.chat https://*.crisp.chat; connect-src 'self' https: https://client.crisp.chat https://*.crisp.chat wss://*.crisp.chat; font-src 'self' https: data:; report-to csp-endpoint;"
     Report-To = '{"group":"csp-endpoint","max_age":10886400,"endpoints":[{"url":"https://report-uri.com/"}]}'

--- a/privacy.html
+++ b/privacy.html
@@ -58,8 +58,9 @@
     <h2>5. Vos droits</h2>
     <p>Accès, rectification, effacement, limitation, opposition, portabilité. Exercer vos droits auprès de : <strong><em>[À RENSEIGNER — EMAIL DÉDIÉ]</em></strong>.</p>
 
-    <h2>6. Public visé</h2>
-    <p>Le service est strictement réservé aux personnes de <strong>18 ans et plus</strong>.</p>
-  </div>
-</body>
-</html>
+      <h2>6. Public visé</h2>
+      <p>Le service est strictement réservé aux personnes de <strong>18 ans et plus</strong>.</p>
+    </div>
+    <script src="chat.js"></script>
+  </body>
+  </html>

--- a/profile-public.html
+++ b/profile-public.html
@@ -81,10 +81,11 @@ async function load(){
 }
 load();
 
-onAuthStateChanged(auth,(u)=>{
-  // s'il n'est pas connecté, on laisse quand même voir le profil public;
-  // le bouton message ouvrira conversations.html qui gèrera l'auth/vérif
-});
-</script>
-</body>
-</html>
+  onAuthStateChanged(auth,(u)=>{
+    // s'il n'est pas connecté, on laisse quand même voir le profil public;
+    // le bouton message ouvrira conversations.html qui gèrera l'auth/vérif
+  });
+  </script>
+ <script src="chat.js"></script>
+ </body>
+ </html>

--- a/profile.html
+++ b/profile.html
@@ -78,8 +78,9 @@
         });
         showToast('Profil enregistré');
       }catch(ex){ alert(ex?.message||'Erreur'); }
-      finally{ btn.disabled=false; btn.textContent=t; }
-    });
+    finally{ btn.disabled=false; btn.textContent=t; }
+  });
   </script>
+  <script src="chat.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expose Crisp chat config in global config
- inject chat loader across public pages
- allow Crisp domains in CSP

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c1ce129c832abb021ffd53771a13