### PR TITLE
feat: configure chat and signed Cloudinary uploads

### DIFF
--- a/config.js
+++ b/config.js
@@ -26,7 +26,13 @@ window.APP_CONFIG = {
   // Cloudinary (client — aucun secret ici)
   cloudinary: {
     cloudName: "dyqxadd0j",
-    unsignedPreset: "lovenow-direct-upload"
+    unsignedPreset: "lovenow-direct-upload",
+    useSigned: true
+  },
+
+  chat: {
+    provider: "crisp",
+    siteId: "42383cbe-1349-42c2-a0ef-04386b58ccd6"
   },
 
   analyticsEnabled: false,


### PR DESCRIPTION
## Summary
- expose chat provider and site ID in APP_CONFIG
- enable signed Cloudinary uploads with fallback support

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1cbda4040832abe7f8fe4359091b5